### PR TITLE
-pie-png-fix

### DIFF
--- a/sources/BackgroundStyleInfo.js
+++ b/sources/BackgroundStyleInfo.js
@@ -271,14 +271,23 @@ PIE.BackgroundStyleInfo = PIE.StyleInfoBase.newStyleInfo( {
         return el.style[ this.styleProperty ] || el.currentStyle.getAttribute( this.cssProperty );
     } ),
 
+	/**
+	 * Tests if style.PiePngFix or the -pie-png-fix property is set to true/on.
+	 */
+	isPngFix: PIE.StyleInfoBase.cacheWhenLocked( function() {
+        var el = this.targetElement;
+        var val = (el.style.PiePngFix || el.currentStyle.getAttribute( 'pie-png-fix' ));
+        return /^(true|on)$/i.test(val);
+    } ),
+    
     /**
      * The isActive logic is slightly different, because getProps() always returns an object
      * even if it is just falling back to the native background properties.  But we only want
-     * to report is as being "active" if the -pie-background override property is present and
-     * parses successfully.
+     * to report is as being "active" if either the -pie-background override property is present
+     * and parses successfully or '-pie-png-fix' is set to true/on.
      */
     isActive: PIE.StyleInfoBase.cacheWhenLocked( function() {
-        return this.getCss3() && !!this.getProps();
+        return (this.getCss3() || this.isPngFix()) && !!this.getProps();
     } )
 
 } );


### PR DESCRIPTION
In order to use a PNG24 as CSS sprite, you currently have to repeat the complete `-pie-background` property, resulting in a duplicate definition for each tile:

```
.button {
  background-image: url(sprite.png);
  behavior: url(PIE.htc);
}

.foo-button { background-position: −16px 0; -pie-background: url(sprite.png) −16px 0 }
.bar-button { background-position: −32px 0; -pie-background: url(sprite.png) −32px 0 }
...
```

This patch adds support for a more compact style that is somewhat easier to maintain:

```
.button {
  background-image: url(sprite.png);
  -pie-png-fix: on;
  behavior: url(PIE.htc);
}

.foo-button { background-position: −16px 0 }
.bar-button { background-position: −32px 0 }
...
```

As PIE already processes the standard background properties if no `-pie-background` is present, all we have to do is to find a way to tell the `isActive()` method to return `true` in this case.

This patch does this by introducing a new property called `-pie-png-fix` which I think is quite intuitive.

Looking at the open issues I noticed that some people don't seem to be aware of the fact, that PIE can be used as 'PNG fix', as they use it together with DD_belatedPNG. So it might be worth to add a hint to the docs.
