### PR TITLE
IE9 'detach' fix

### DIFF
--- a/sources/htc_init.js
+++ b/sources/htc_init.js
@@ -10,7 +10,7 @@ function init() {
 function cleanup() {
     if( p ) {
         if( p['detach'] ) { // This is to cope with the following error in IE9: Object doesn't support property or method 'detach'
-	        p['detach']( el );
+            p['detach']( el );
         }
         p = el = 0;
     }


### PR DESCRIPTION
When using the htc file in IE9, the following error gets thrown when entering into the cleanup method: Object doesn't support property or method 'detach'.

My fix just does a simple check to make sure 'detach' is defined before calling it.  Sorry for the multiple commits for such a simple change, but I accidentally committed with tabs instead of spaces, which jacked up the formatting.  So the last commits just fix the formatting.

I think this is the only place that needed this check... not 100% sure though.  Everything has been working smoothly with IE9 for me since this fix (I give it the "works on my machine" stamp)  :-)
