### PR TITLE
ie8 display none/block on hovers

### DIFF
--- a/sources/RootRenderer.js
+++ b/sources/RootRenderer.js
@@ -61,6 +61,7 @@ PIE.RootRenderer = PIE.RendererBase.newRenderer( {
             s.top = y;
             s.zIndex = tgtPos === 'static' ? -1 : tgtCS.zIndex;
             this.isPositioned = true;
+            this.updateVisibility();
         }
     },
 


### PR DESCRIPTION
Added a call to updateVisibility, i had issues in ie8 , please see http://catalint.ro/ie8/ for further debugging.
there should be some other fixes for the "flick" you see in ie8 before update movie but right now it's good enough for me

hope this one helps you more :)
