### PR TITLE
Set a min-width for source code panel

### DIFF
--- a/demos/gradient-patterns.html
+++ b/demos/gradient-patterns.html
@@ -76,6 +76,7 @@
         #patternGallery pre {
             margin: 0 240px 0 0;
             max-height: 250px;
+            min-width: 344px;
             overflow: auto;
             background: #eee;
             border: 1px solid #ccc;


### PR DESCRIPTION
The width of source code panel on [demos/gradient-patterns/](http://css3pie.com/demos/gradient-patterns/) page appears a bit narrow in WebKit browsers.
