### PR TITLE
Hidden elements error fix

### DIFF
--- a/sources/BoxShadowOutsetRenderer.js
+++ b/sources/BoxShadowOutsetRenderer.js
@@ -86,7 +86,7 @@ PIE.BoxShadowOutsetRenderer = PIE.RendererBase.newRenderer( {
             }
             path = this.getBoxPath( { t: shrink, r: shrink, b: shrink, l: shrink }, 2, radii );
 
-            if( blur ) {
+            if( (( w + h ) > 0 ) && blur ) {
                 totalW = ( spread + blur ) * 2 + w;
                 totalH = ( spread + blur ) * 2 + h;
                 focusX = blur * 2 / totalW;


### PR DESCRIPTION
Sometimes PIE can throw a vector2d error when trying to render an element that is hidden, which means 0 width/height.
I added a check for those values to make sure that the element being processed is valid.

This fix prevents rendering in those cases - tested and working.
