### PR TITLE
Update documentation/pie-js.html

### DIFF
--- a/documentation/pie-js.html
+++ b/documentation/pie-js.html
@@ -60,7 +60,7 @@ to work with, for example allowing the use of CSS selectors to match a set of el
 
 <ol>
     <li>Include the PIE.js script in your page, surrounded by a conditional comment to prevent it from being downloaded in other browsers:
-        <pre><code>&lt;!--[if lt IE 10]>
+        <pre><code>&lt;!--[if IE]>
 &lt;script type="text/javascript" src="path/to/PIE.js">&lt;/script>
 &lt;![endif]--></code></pre>
     </li>


### PR DESCRIPTION
The conditional comment [if lt IE 10] can be reduced to [if IE] since IE 10 doesn't read conditional comments:

https://blogs.msdn.com/b/ie/archive/2011/07/06/html5-parsing-in-ie10.aspx
