### PR TITLE
Strip single quotes as well as double from `pie-load-path`

### DIFF
--- a/sources/htc_script.js
+++ b/sources/htc_script.js
@@ -32,7 +32,7 @@ if ( !window[ 'PIE' ] && docMode < 10 ) {
         // Look for a custom -pie-load-path, or fall back to the CDN url
         baseUrl = doc.documentElement.currentStyle.getAttribute( ( isIE6 ? '' : '-' ) + 'pie-load-path' );
         if( baseUrl ) {
-            baseUrl = baseUrl.replace(/^"|"$/g, '');
+            baseUrl = baseUrl.replace(/^("|')|("|')$/g, '');
             baseUrls = [ baseUrl ];
         }
 


### PR DESCRIPTION
pie-load-path can contain url in single quotes. IE8 translates them to double, but IE7 preserves single
