### PR TITLE
Fix for issue 149

### DIFF
--- a/sources/StyleInfoBase.js
+++ b/sources/StyleInfoBase.js
@@ -51,7 +51,7 @@ PIE.StyleInfoBase = {
         var el = this.targetElement,
             ctor = this.constructor,
             s = el.style,
-            cs = el.currentStyle,
+            cs = el.currentStyle || {getAttribute:{}},
             cssProp = this.cssProperty,
             styleProp = this.styleProperty,
             prefixedCssProp = ctor._prefixedCssProp || ( ctor._prefixedCssProp = PIE.CSS_PREFIX + cssProp ),


### PR DESCRIPTION
currentStyle is Async in IE, and/or may be null if an element is created using createElement.  Either way, PIE needs to make sure currentStyle is present before accessing its methods.

(see http://stackoverflow.com/questions/3722736/weird-ie-behavior-currentstyle-returns-null)
