### PR TITLE
Avoid error in accessing window.PIE

### DIFF
--- a/sources/htc_script.js
+++ b/sources/htc_script.js
@@ -92,12 +92,12 @@ function init() {
 }
 
 function cleanup() {
-    if ( doc.media !== 'print' ) {
+    try {
         var PIE = window[ 'PIE' ];
         if ( PIE ) {
             PIE[ 'detach' ]( el );
         }
-    }
+    } catch (e) {}
     el = 0;
 }
 


### PR DESCRIPTION
Occasionally I got an error when the cleanup function was run. Internet Explorer didn't actually indicate what the problem was. Just an error on that line. When I typed "window" into the console while the debugger was paused at the line I didn't get a problem. But when I typed "window.PIE" or "window['PIE']" I got the error again. So it is some problem in accessing the PIE object and even just testing for it's existence gives the error.

Found a [forum post][1] that suggested using a try/catch block. When I tried that the error went away.

Since the try/catch block will catch any error the check for printing didn't seem necessary anymore. So I just removed it.

[1] http://css3pie.com/forum/viewtopic.php?p=4765&sid=c961044763dea6c94d71cd790f52ad1b#p4765
