### PR TITLE
Update PIE.php

### DIFF
--- a/sources/wrappers/PIE.php
+++ b/sources/wrappers/PIE.php
@@ -15,4 +15,4 @@ case with some shared hosting providers).
 */
 
 header( 'Content-type: text/x-component' );
-include 'PIE.htc';
+readfile('PIE.htc');


### PR DESCRIPTION
`readfile()` is preferable to `include` when you're simply piping a file to stdout. It removes the overhead of trying to parse a non-PHP file as PHP, and also eliminates any chance of unwanted code execution.
