### PR TITLE
Fixed error "Uncaught TypeError: .attachEvent is not a function".

### DIFF
--- a/sources/Element.js
+++ b/sources/Element.js
@@ -348,7 +348,11 @@ PIE.Element = (function() {
 
 
         function addListener( targetEl, type, handler ) {
-            targetEl.attachEvent( type, handler );
+            if (targetEl.addEventListener) {
+                targetEl.addEventListener(type.substr(2), handler, false);
+            } else if (targetEl.attachEvent) {
+                targetEl.attachEvent(type, handler);
+            }
             eventListeners.push( [ targetEl, type, handler ] );
         }
 

--- a/sources/OnUnload.js
+++ b/sources/OnUnload.js
@@ -10,13 +10,21 @@
         win[ 'PIE' ] = null;
     }
 
-    win.attachEvent( 'onunload', handleUnload );
+    if (win.addEventListener) {
+        win.addEventListener('unload', handleUnload, false);
+    } else if (win.attachEvent) {
+        win.attachEvent('onunload', handleUnload);
+    }
 
     /**
      * Attach an event which automatically gets detached onunload
      */
     PIE.OnUnload.attachManagedEvent = function( target, name, handler ) {
-        target.attachEvent( name, handler );
+        if (target.addEventListener) {
+            target.addEventListener(name.substr(2), handler, false);
+        } else if (target.attachEvent) {
+            target.attachEvent(name, handler);
+        }
         this.observe( function() {
             target.detachEvent( name, handler );
         } );


### PR DESCRIPTION
Fixed error "Uncaught TypeError: .attachEvent is not a function".
Documentation on https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#Legacy_Internet_Explorer_and_attachEvent